### PR TITLE
Fix broken builds by removing malfunctioning Toolbox

### DIFF
--- a/bin/steps/swift
+++ b/bin/steps/swift
@@ -4,7 +4,7 @@ cd "$BUILD_DIR"
 echo "Swift 3 Heroku Installer";
 
 # Determine version
-VERSION="3.0.1"
+VERSION="3.0.2"
 if [ -f "$BUILD_DIR/.swift-version" ]
 then
     VERSION_FILE=".swift-version"

--- a/bin/steps/swift-build
+++ b/bin/steps/swift-build
@@ -1,25 +1,4 @@
 cd $BUILD_DIR
 
-puts-step "Installing toolbox"
-
-echo "Downloading...";
-git clone https://github.com/vapor/toolbox vapor-toolbox > /dev/null 2>&1;
-cd vapor-toolbox;
-
-TOOLBOXTAG=$(git describe --tags);
-git checkout $TOOLBOXTAG > /dev/null 2>&1;
-rm -rf .swift-version
-
-echo "Compiling...";
-swift build -Xswiftc -DNO_ANIMATION > /dev/null;
-
-echo "Installing...";
-mv .build/debug/Executable ../vapor;
-cd ..;
-rm -rf vapor-toolbox;
-
-puts-step "Fetching Packages ... this will take a while"
-swift package fetch
-
 puts-step "Building Package ... this will take a while"
-./vapor build $SWIFT_BUILD_FLAGS --release --verbose
+swift build $SWIFT_BUILD_FLAGS -c release


### PR DESCRIPTION
Old and new projects are all killed by the sneaky changes in the Toolbox.
This PR removes the toolbox while bumping Swift to 3.0.2 to ensure that everyone trying to use Vapor or maintain their existing applications is actually capable to do so.

Resolves vapor/vapor#946.