### PR TITLE
Work around swiftly install behaviors

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,6 @@
 set -e
 set -o pipefail
 
-
 BIN_DIR=$(
   cd $(dirname $0)
   pwd
@@ -34,7 +33,6 @@ fi
 SWIFT_VERSION="latest"
 SWIFT_BUILD_CONFIGURATION="release"
 SWIFT_BUILD_FLAGS=""
-
 
 if [ -f "$BUILD_DIR/.swift-version" ]; then
   SWIFT_VERSION=$(cat "$BUILD_DIR/.swift-version" | tr -d '[[:space:]]')
@@ -64,7 +62,7 @@ else
   SWIFT_BACKTRACE_EXECUTABLE="swift-backtrace-static"
 fi
 
-mkdir -p "$CACHE_DIR/$STACK"
+mkdir -p "$CACHE_DIR"
 source "$BIN_DIR/steps/swiftly"
 
 cd "$BUILD_DIR"

--- a/bin/steps/swiftly
+++ b/bin/steps/swiftly
@@ -1,19 +1,10 @@
-export SWIFTLY_HOME_DIR="$CACHE_DIR/$STACK/share/swiftly"
-export SWIFTLY_BIN_DIR="$CACHE_DIR/$STACK/bin"
-export PATH="$SWIFTLY_BIN_DIR:$PATH"
+puts-step Installing swiftly...
 
-if [ -d "$SWIFTLY_HOME_DIR" ]; then
-  puts-step "Swiftly already installed, updating..."
-  swiftly self-update
-else
-  puts-step Installing swiftly...
-
-  curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
-    tar zxf swiftly-$(uname -m).tar.gz && \
-    ./swiftly init --quiet-shell-followup && \
-    . ~/.local/share/swiftly/env.sh && \
-    hash -r
-fi
+curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
+  tar zxf swiftly-$(uname -m).tar.gz && \
+  ./swiftly init --quiet-shell-followup && \
+  . ~/.local/share/swiftly/env.sh && \
+  hash -r
 
 puts-step Installing Swift...
 swiftly install --use $SWIFT_VERSION

--- a/bin/steps/swiftly
+++ b/bin/steps/swiftly
@@ -2,9 +2,9 @@ puts-step Installing swiftly...
 
 curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
   tar zxf swiftly-$(uname -m).tar.gz && \
-  ./swiftly init --quiet-shell-followup && \
+  ./swiftly init --quiet-shell-followup --skip-install -y && \
   . ~/.local/share/swiftly/env.sh && \
   hash -r
 
 puts-step Installing Swift...
-swiftly install --use $SWIFT_VERSION
+swiftly install --use $SWIFT_VERSION --post-install-file __fake_post_install.sh --verbose


### PR DESCRIPTION
1. `swiftly init` got the `--skip-install` parameter, so it doesn't unconditionally install Swift 6.1.0.
2. `swiftly install` [fails](https://github.com/swiftlang/swiftly/blob/bd30c0590e3d575478e2f02d4b364f292a3507dd/Sources/Swiftly/Install.swift#L128-L136) if there are any post-install steps to run, which is not a problem for the `init` command but certainly breaks the build. A temporary file is used to satisfy the guard statement.